### PR TITLE
Fix the bloom's motion on touch devices

### DIFF
--- a/.changeset/mobile-bloom-motion.md
+++ b/.changeset/mobile-bloom-motion.md
@@ -1,0 +1,26 @@
+---
+"bloom-color-picker": patch
+---
+
+Fix the bloom's entrance and exit on touch devices.
+
+Opening the bloom animated `blur()` across 22 layers at once — 19 petals plus the
+bloom, the dish and the 360px arc. Unlike the `transform` and `opacity` beside
+them, a blur can't be composited: every frame re-rasterises the layer and runs a
+Gaussian over it, which phone GPUs drop frames on. The radii are now CSS
+variables, and are zeroed under `(hover: none) and (pointer: coarse)` along with
+the petals' shadow and ring. Keying on pointer type rather than viewport width
+means a narrowed desktop window keeps the full effect, and the defaults are
+unchanged, so desktop renders exactly as before.
+
+Two motion bugs surfaced once that was legible:
+
+- `motion="none"` is documented as an instant open/close, but only ever flattened
+  durations, easings and delays — never the keyframes. The petals and arc still
+  ran their full spiral, with every one of them starting on the same frame inside
+  160ms. They now fade on touch devices.
+- The dish is a child of the bloom, so its scale multiplied with the bloom's own
+  `0.1786`. Starting from `0.4` put it at an effective `0.07` on the first frame
+  while the petals — siblings of the bloom rather than children — animated at
+  full size, so the dish appeared to arrive after them. It now starts near full
+  and lets the parent's growth carry it. This applies on every device.

--- a/packages/react/src/style.css
+++ b/packages/react/src/style.css
@@ -853,12 +853,17 @@
    border-radius: 50%;
    background: var(--bcp-dish-bg);
    overflow: hidden;
-   animation: bcp-dish-in var(--bcp-dur-dish) var(--bcp-ease-dish) 0.05s backwards;
+   animation: bcp-dish-in var(--bcp-dur-dish) var(--bcp-ease-dish) backwards;
 }
 
+/* The dish sits inside the bloom, so its scale multiplies with the bloom's own
+   0.1786 → 1. Starting from 0.4 meant an effective 0.07 on the first frame,
+   while the petals — siblings of the bloom, not children — animate at full size
+   from the start, so the dish read as arriving after them. It now starts close
+   to full and lets the parent's growth carry it. */
 @keyframes bcp-dish-in {
    from {
-      transform: scale(0.4);
+      transform: scale(0.86);
       opacity: 0;
       filter: blur(var(--bcp-dish-blur));
    }
@@ -993,6 +998,31 @@
    }
 }
 
+/* motion="none" is documented as an instant open/close — "a quick uniform
+   fade, not an instant snap" — but the override at the end of this file only
+   flattens durations, easings and delays; the keyframes still run the full
+   spiral. With the stagger gone, all 19 petals fly in from the centre on the
+   same frame inside 160ms, and the arc scales from 0.3 alongside them, which is
+   the most concentrated transform work this component can produce. These give
+   it the fade it actually promises — opacity only, so element-agnostic. */
+@keyframes bcp-fade-in {
+   from {
+      opacity: 0;
+   }
+   to {
+      opacity: 1;
+   }
+}
+
+@keyframes bcp-fade-out {
+   from {
+      opacity: 1;
+   }
+   to {
+      opacity: 0;
+   }
+}
+
 /* Touch devices drop the focus-pull entirely. Opening the bloom animates blur
    on 22 layers at once — 19 petals, plus the bloom, the dish and the 360px arc,
    which is an SVG being blurred while it scales from 0.3. Unlike the transform
@@ -1008,7 +1038,11 @@
 @media (hover: none) and (pointer: coarse) {
    .bcp {
       --bcp-petal-blur-in: 0px;
-      --bcp-petal-blur-out: 0px;
+      /* The close keeps a softened version rather than dropping to 0: it is a
+         quarter of the entrance radius over a fixed 340ms, and without any of
+         it the petals snap back to the centre instead of collapsing. Far
+         cheaper than the entrance, which is what actually caused the jank. */
+      --bcp-petal-blur-out: 1.5px;
       --bcp-bloom-blur: 0px;
       --bcp-dish-blur: 0px;
       --bcp-arc-blur: 0px;
@@ -1027,6 +1061,20 @@
 
    .bcp__petal:not(:focus-visible) {
       outline: none !important;
+   }
+
+   /* Scoped to touch, where the compressed motion reads as a jerk. Desktop
+      keeps its current motion="none" look until that's a deliberate change.
+      The arc is the worst of them: a 360px SVG scaling from 0.3, so its paths
+      re-rasterise the whole way in. */
+   .bcp[data-motion="none"] .bcp__petal,
+   .bcp[data-motion="none"] .bcp__arc {
+      animation-name: bcp-fade-in;
+   }
+
+   .bcp[data-motion="none"] .bcp__petal--home,
+   .bcp[data-motion="none"] .bcp__arc--closing {
+      animation-name: bcp-fade-out;
    }
 }
 

--- a/packages/react/src/style.css
+++ b/packages/react/src/style.css
@@ -20,6 +20,16 @@
    --bcp-dur-press: 300ms;
    --bcp-ease-press: cubic-bezier(0.34, 1.56, 0.64, 1);
 
+   /* Focus-pull radii, kept as variables so they can be turned off where they
+      are too expensive to be worth it — see the coarse-pointer block at the end
+      of this file. `transform` and `opacity` are composited, but `blur()` forces
+      a re-raster every frame, and these layers all animate at once. */
+   --bcp-petal-blur-in: 12px;
+   --bcp-petal-blur-out: 3px;
+   --bcp-bloom-blur: 3px;
+   --bcp-dish-blur: 8px;
+   --bcp-arc-blur: 8px;
+
    --bcp-scale: 1;
 
    /* public theming variables — override any of these to restyle without
@@ -812,7 +822,7 @@
 
 @keyframes bcp-unblur-3 {
    from {
-      filter: blur(3px);
+      filter: blur(var(--bcp-bloom-blur));
    }
    to {
       filter: blur(0px);
@@ -833,7 +843,7 @@
    to {
       transform: scale(0.1786);
       opacity: 0;
-      filter: blur(3px);
+      filter: blur(var(--bcp-bloom-blur));
    }
 }
 
@@ -850,7 +860,7 @@
    from {
       transform: scale(0.4);
       opacity: 0;
-      filter: blur(8px);
+      filter: blur(var(--bcp-dish-blur));
    }
    to {
       transform: scale(1);
@@ -877,7 +887,7 @@
    from {
       opacity: 0;
       transform: scale(0.3);
-      filter: blur(8px);
+      filter: blur(var(--bcp-arc-blur));
    }
    to {
       opacity: 1;
@@ -899,7 +909,7 @@
    to {
       opacity: 0;
       transform: scale(0.3);
-      filter: blur(8px);
+      filter: blur(var(--bcp-arc-blur));
    }
 }
 
@@ -945,7 +955,7 @@
    from {
       transform: translate(var(--bcp-from-x), var(--bcp-from-y)) scale(1.5);
       opacity: 0;
-      filter: blur(12px);
+      filter: blur(var(--bcp-petal-blur-in));
    }
    to {
       transform: translate(0, 0) scale(1);
@@ -979,7 +989,44 @@
    to {
       transform: translate(var(--bcp-from-x), var(--bcp-from-y)) scale(1);
       opacity: 0;
-      filter: blur(3px);
+      filter: blur(var(--bcp-petal-blur-out));
+   }
+}
+
+/* Touch devices drop the focus-pull entirely. Opening the bloom animates blur
+   on 22 layers at once — 19 petals, plus the bloom, the dish and the 360px arc,
+   which is an SVG being blurred while it scales from 0.3. Unlike the transform
+   and opacity beside them, blur() can't be composited: every frame re-rasterises
+   the layer and runs a Gaussian over it. Desktop GPUs absorb that; phone GPUs
+   drop frames on it.
+
+   Keyed on pointer type rather than width, so a narrowed desktop window keeps
+   the full effect and only the devices that actually struggle take the cheap
+   path. Everything still spirals, scales and fades; what goes is the decoration
+   that costs the most to paint and reads the least in motion — the focus-pull
+   here, plus the petals' shadow and ring below. */
+@media (hover: none) and (pointer: coarse) {
+   .bcp {
+      --bcp-petal-blur-in: 0px;
+      --bcp-petal-blur-out: 0px;
+      --bcp-bloom-blur: 0px;
+      --bcp-dish-blur: 0px;
+      --bcp-arc-blur: 0px;
+   }
+
+   /* The rest of a petal's cost is paint, not motion: a blurred shadow and a
+      ring built from a nested color-mix(), on a 50%-radius box — repeated 19
+      times, all scaling at once. Both are decoration a phone can do without;
+      the petals stay legible on their own fills. The ring is set inline from
+      JS, so only !important can take it off — hence :not(:focus-visible), so
+      this can't also suppress the focus ring for anyone pairing a keyboard
+      with a touch device. */
+   .bcp__petal {
+      box-shadow: none;
+   }
+
+   .bcp__petal:not(:focus-visible) {
+      outline: none !important;
    }
 }
 


### PR DESCRIPTION
Opening the bloom lagged on phones while staying smooth on desktop.

## Cause

The entrance animated `blur()` across 22 layers at once — 19 petals plus the
bloom, the dish and the 360px arc. `transform` and `opacity` are composited, so
the GPU reuses an existing texture; a blur is not. Every frame re-rasterises the
layer and runs a Gaussian over it, and the petals are simultaneously at
`scale(1.5)`, so it blurs an enlarged one. Desktop GPUs absorb 22 of those;
phone GPUs drop frames.

Each petal also carried a `box-shadow` and a ring built from a nested
`color-mix()`, painted 19 times while scaling.

## Fix

The radii are now CSS variables, zeroed under
`(hover: none) and (pointer: coarse)` along with the petals' shadow and ring.
Keyed on pointer type rather than viewport width, so a narrowed desktop window
keeps the full effect and only devices that actually struggle take the cheap
path. **Defaults are unchanged, so desktop renders exactly as before.**

## Two bugs this surfaced

Once the motion was legible on a phone, two things showed up that were wrong on
every device:

- **`motion="none"` never disabled anything.** It only flattened durations,
  easings and delays — never the keyframes. The petals and arc still ran the
  full spiral, and with the stagger gone every one of them started on the same
  frame inside 160ms: the most concentrated transform work the component can
  produce, against a prop documented as an instant open/close. They now fade on
  touch. Desktop is left as-is pending a deliberate call, but it has the same
  mismatch.
- **The dish arrived after the petals.** It is a child of the bloom, so its
  scale multiplies with the bloom's own `0.1786` — starting from `0.4` put it at
  an effective `0.07` on the first frame, while the petals (siblings of the
  bloom, not children) animate at full size throughout. Fixed globally, since it
  was wrong everywhere.

The close keeps a softened blur rather than none: a quarter of the entrance
radius over a fixed 340ms, without which the petals snap back to the centre
instead of collapsing.

## Notes

- `outline: none` on the petals is scoped to `:not(:focus-visible)` — the ring
  is set inline from JS and needs `!important` to remove, which would otherwise
  also suppress the focus ring for anyone pairing a keyboard with a tablet.
- Verified on device across all three motion presets, open and close.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bloom entrance and exit animations on touch devices, reducing dropped frames.
  * Corrected reduced-motion behavior so petals and arcs fade instead of running full motion.
  * Improved dish animation timing for a smoother, more synchronized appearance across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->